### PR TITLE
build: Add option to disable block-based ota

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1720,13 +1720,17 @@ ifneq ($(TARGET_UNIFIED_DEVICE),)
     endif
 endif
 
+ifneq ($(BLOCK_BASED_OTA),false)
+    $(INTERNAL_OTA_PACKAGE_TARGET): block_based := --block
+endif
+
 $(INTERNAL_OTA_PACKAGE_TARGET): $(BUILT_TARGET_FILES_PACKAGE) $(DISTTOOLS)
 	@echo "$(OTA_FROM_TARGET_SCRIPT)" > $(PRODUCT_OUT)/ota_script_path
 	@echo "$(override_device)" > $(PRODUCT_OUT)/ota_override_device
 	@echo -e ${CL_YLW}"Package OTA:"${CL_RST}" $@"
 	$(hide) MKBOOTIMG=$(MKBOOTIMG) \
 	   $(OTA_FROM_TARGET_SCRIPT) -v \
-	   --block \
+	   $(block_based) \
 	   $(if $(WITH_LZMA_OTA), -z) \
 	   -p $(HOST_OUT) \
 	   -k $(KEY_CERT_PAIR) \


### PR DESCRIPTION
While block-based is great when building on a local machine, it kills rsync
performance when syncing rebuilds from remote machines.  Provide an option
to disable it for those whose network bandwidth is less than their device's
emmc bandwidth.

Usage: export BLOCK_BASED_OTA=false