### PR TITLE
Disable block based ota

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -2801,12 +2801,16 @@ else
 endif
 endif
 
+ifneq ($(BLOCK_BASED_OTA),false)
+    $(INTERNAL_OTA_PACKAGE_TARGET): block_based := --block
+endif
+
 $(INTERNAL_OTA_PACKAGE_TARGET): $(BUILT_TARGET_FILES_PACKAGE) \
 		build/tools/releasetools/ota_from_target_files
 	@echo "Package OTA: $@"
 	$(hide) PATH=$(foreach p,$(INTERNAL_USERIMAGES_BINARY_PATHS),$(p):)$$PATH MKBOOTIMG=$(MKBOOTIMG) \
 	   ./build/tools/releasetools/ota_from_target_files -v \
-	   --block \
+	   $(block_based) \
 	   --extracted_input_target_files $(patsubst %.zip,%,$(BUILT_TARGET_FILES_PACKAGE)) \
 	   -p $(HOST_OUT) \
 	   -k $(KEY_CERT_PAIR) \


### PR DESCRIPTION
Add "BLOCK_BASED_OTA" option that can be defined in the "boardconfig.mk" to build file-based ota build instead of block-based ota build. This modified Makefile allows us to disable block based ota with "BLOCK_BASED_OTA := false".

An alternative way, is that you have to remove the "--block" line manually from "android_build/core/Makefile" every time.