### PR TITLE
Allow signing using Python 3

### DIFF
--- a/tools/releasetools/add_img_to_target_files.py
+++ b/tools/releasetools/add_img_to_target_files.py
@@ -205,7 +205,7 @@ def AddVendor(output_zip, recovery_img=None, boot_img=None):
 
   def output_sink(fn, data):
     ofile = open(os.path.join(OPTIONS.input_tmp, "VENDOR", fn), "w")
-    ofile.write(data)
+    ofile.write(str(data))
     ofile.close()
 
     if output_zip:

--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -702,7 +702,7 @@ def LoadInfoDict(input_file, repacking=False):
     for partition in PARTITIONS_WITH_CARE_MAP:
       fingerprint = build_info.GetPartitionFingerprint(partition)
       if fingerprint:
-        d["avb_{}_salt".format(partition)] = sha256(fingerprint).hexdigest()
+        d["avb_{}_salt".format(partition)] = sha256(fingerprint.encode()).hexdigest()
 
   return d
 


### PR DESCRIPTION
Please review the changes, but I was able to make a successful signing process without Python 2 at my system.

Without those changes, I must instance a Python 2 to run **sign_target_files_apks** and **ota_from_target_files** or fails with "Encoding" and "Bytes" errors. 